### PR TITLE
fix: compare in the same case

### DIFF
--- a/src/CallbackNotification.php
+++ b/src/CallbackNotification.php
@@ -144,7 +144,7 @@ class CallbackNotification
 
         $hmac = hash_hmac('sha256', $this->getCheckString(), $symmetric_private_key);
 
-        return $hmac === $this->getChecksum();
+        return strtoupper($hmac) === strtoupper($this->getChecksum());
     }
 
     /**


### PR DESCRIPTION
Из описания контрольной суммы у Сбера:

> В получившейся строке контрольной суммы все буквы нижнего регистра заменяются на буквы верхнего регистра.

Сейчас регистр не совпадает (рассчитываемая контрольная сумма в нижнем, сбер присылает в верхнем)

Добавил явное преобразование обеих строк в верхний регистр